### PR TITLE
feat: move backbone from dependencies to peerDependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ yarn lint
 
 ## Build
 
-Source code is written in *ECMAScript 6*. Build by
+Source code is written in *ECMAScript 2015+*. Build by
 
 - [Babel](https://babeljs.io/)
 - [Webpack](https://webpack.github.io/)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@
 
 ## Install
 
-```sh
-npm install backbone.deepmodel --save
-```
+via NPM:
 
 ```sh
-yarn add backbone.deepmodel
+npm install backbone backbone.deepmodel
+```
+
+via Yarn:
+
+```sh
+yarn add backbone backbone.deepmodel
 ```
 
 Or download manually:

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "lib"
   ],
   "keywords": [
-    "backbone"
+    "backbone",
+    "plugin"
   ],
   "author": "ybiquitous <ybiquitous@gmail.com>",
   "license": "MIT",
   "repository": "ybiquitous/backbone.deepmodel",
   "homepage": "https://github.com/ybiquitous/backbone.deepmodel",
-  "dependencies": {
+  "peerDependencies": {
     "backbone": ">=1.2.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "babel-plugin-transform-object-assign": "*",
     "babel-preset-env": "*",
     "babel-preset-power-assert": "*",
+    "backbone": ">=1.2.0",
     "benchmark": "*",
     "conventional-github-releaser": "*",
     "dotenv": "*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-transform-object-assign": "*",
     "babel-preset-env": "*",
     "babel-preset-power-assert": "*",
-    "backbone": ">=1.2.0",
+    "backbone": "*",
     "benchmark": "*",
     "conventional-github-releaser": "*",
     "dotenv": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,7 +883,7 @@ babylon@^6.1.0, babylon@^6.17.2, babylon@^6.17.4, babylon@^6.7.0:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
-backbone@>=1.2.0:
+backbone@*:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.3.3.tgz#4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
   dependencies:


### PR DESCRIPTION
In plugin package, to list host package as `peerDependencies` is recommended.

See https://docs.npmjs.com/files/package.json#peerdependencies